### PR TITLE
Changed old live stream check to use started date rather than creation date

### DIFF
--- a/src/hooks/useLiveStreams.ts
+++ b/src/hooks/useLiveStreams.ts
@@ -34,7 +34,7 @@ export function useSortedStreams(feed: Array<TaggedNostrEvent>, oldest?: number)
   }
 
   const live = feedSorted
-    .filter(a => a.created_at > (oldest ?? unixNow() - 7 * DAY))
+    .filter(a => findTag(a, "starts") <= unixNow() && findTag(a, "starts") > (unixNow() - DAY))
     .filter(a => {
       try {
         return findTag(a, "status") === StreamState.Live && canPlayEvent(a);


### PR DESCRIPTION
The Zap.stream code seems to ignore live streams that were set up weeks ago even if they are valid live streams. This change uses the started date to determine whether it's a genuine live stream or one that someone forgot to shut off