### PR TITLE
Fix missing Recording URL field on ended streams

### DIFF
--- a/src/element/stream-editor/index.tsx
+++ b/src/element/stream-editor/index.tsx
@@ -212,12 +212,20 @@ export function StreamEditor({ ev, onFinish, options }: StreamEditorProps) {
               />
             </StreamInput>
           )}
-          {status === StreamState.Ended && (
-            <StreamInput label={<FormattedMessage defaultMessage="Recording URL" />}>
-              <input type="text" value={recording} onChange={e => setRecording(e.target.value)} />
-            </StreamInput>
-          )}
         </>
+      )}
+      {status === StreamState.Ended && (
+        <StreamInput label={<FormattedMessage defaultMessage="Recording URL" />}>
+          <input
+            type="text"
+            placeholder="https://"
+            value={recording}
+            onChange={e => setRecording(e.target.value)}
+          />
+          <small>
+            <FormattedMessage defaultMessage="Paste a recording URL (HLS .m3u8) to make this stream available on-demand." />
+          </small>
+        </StreamInput>
       )}
       {(options?.canSetTags ?? true) && (
         <CategoryInput


### PR DESCRIPTION
## Problem

The **Recording URL** field disappeared from the stream editor, so ended streams could no longer be given an HLS recording link to make them available on-demand.

## Root cause

The Recording URL input was nested inside the `canSetStatus` block in `StreamEditor`. The dashboard's **Edit Stream Info** flow opens the editor via `NostrProviderDialog` with `canSetStatus: false`, which hides the status selector — and unintentionally hid the Recording URL field along with it, even for ended streams (the one case where it's needed).

This regressed in `a385ca3` ("Move stream setup/config to dashboard").

## Fix

Move the Recording URL field out of the `canSetStatus` block so it renders whenever the stream status is `ended`, independent of the status selector. The publish logic already writes the `["recording", <url>]` tag on the kind 30311 event when status is `ended`, so once the field is visible again, pasting an HLS link and saving makes the stream available on-demand.

## Testing

- Dashboard → ended stream → **Edit Stream Info** → the **Recording URL** line now appears → paste link → **Save**.
- Verified locally via the dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)